### PR TITLE
bluez_helper: ignore non xml lines

### DIFF
--- a/nOBEX/bluez_helper.py
+++ b/nOBEX/bluez_helper.py
@@ -115,8 +115,12 @@ def _search_record(name, bdaddr):
     if val.returncode != 0:
         raise SDPException("sdptool search returned %i" % val.returncode)
 
-    # Strip out first line that's not XML
-    xml_str = b'\n'.join(val.stdout.splitlines()[1:])
+    # Strip out lines that are not XML
+    xml_str = b''
+    for line in val.stdout.splitlines():
+        if not line or (line[0] != ord('<') and line[0] != ord('\t')):
+            continue
+        xml_str += line
 
     serv_count = xml_str.count(b'<record>')
     if serv_count < 1:


### PR DESCRIPTION
Hi,
I ran into a problem while trying to dump MAP data from android.
This was due to non XML Data at the end of sdptool. (It seems to search two times.)

```sh

sdptool search --xml --bdaddr=xx:xx:xx:xx:xx:xx map
Searching for map on xx:xx:xx:xx:xx:xx ...
<?xml version="1.0" encoding="UTF-8" ?>

<record>
	[...]
</record>
Searching for map on xx:xx:xx:xx:xx:xx ...
Service Search failed: Invalid argument
```